### PR TITLE
fix #2293: Properly encode Decimals without any decimal places. (#2294)

### DIFF
--- a/changes/2293-hultner.md
+++ b/changes/2293-hultner.md
@@ -1,0 +1,1 @@
+Properly encode `Decimal` with, or without any decimal places.

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -18,6 +18,27 @@ def isoformat(o: Union[datetime.date, datetime.time]) -> str:
     return o.isoformat()
 
 
+def decimal_encoder(dec_value: Decimal) -> Union[int, float]:
+    """
+    Encodes a Decimal as int of there's no exponent, otherwise float
+
+    This is useful when we use ConstrainedDecimal to represent Numeric(x,0)
+    where a integer (but not int typed) is used. Encoding this as a float
+    results in failed round-tripping between encode and prase.
+    Our Id type is a prime example of this.
+
+    >>> decimal_encoder(Decimal("1.0"))
+    1.0
+
+    >>> decimal_encoder(Decimal("1"))
+    1
+    """
+    if dec_value.as_tuple().exponent >= 0:
+        return int(dec_value)
+    else:
+        return float(dec_value)
+
+
 ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
     bytes: lambda o: o.decode(),
     Color: str,
@@ -25,7 +46,7 @@ ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
     datetime.datetime: isoformat,
     datetime.time: isoformat,
     datetime.timedelta: lambda td: td.total_seconds(),
-    Decimal: float,
+    Decimal: decimal_encoder,
     Enum: lambda o: o.value,
     frozenset: list,
     deque: list,

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, create_model
 from pydantic.color import Color
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 from pydantic.json import pydantic_encoder, timedelta_isoformat
-from pydantic.types import DirectoryPath, FilePath, SecretBytes, SecretStr
+from pydantic.types import ConstrainedDecimal, DirectoryPath, FilePath, SecretBytes, SecretStr
 
 
 class MyEnum(Enum):
@@ -168,6 +168,25 @@ def test_custom_iso_timedelta():
 
     m = Model(x=123)
     assert m.json() == '{"x": "P0DT0H2M3.000000S"}'
+
+
+def test_con_decimal_encode() -> None:
+    """
+    Makes sure a decimal with decimal_places = 0, as well as one with places
+    can handle a encode/decode roundtrip.
+    """
+
+    class Id(ConstrainedDecimal):
+        max_digits = 22
+        decimal_places = 0
+        ge = 0
+
+    class Obj(BaseModel):
+        id: Id
+        price: Decimal = Decimal('0.01')
+
+    assert Obj(id=1).json() == '{"id": 1, "price": 0.01}'
+    assert Obj.parse_raw('{"id": 1, "price": 0.01}') == Obj(id=1)
 
 
 def test_json_encoder_simple_inheritance():


### PR DESCRIPTION
* fix #2293: Properly encode Decimals without any decimal places.

* doc: Added changelog entry.

* refactor: Move ConstrainedDecimal test from separate file into test_json

* docs: Remove prefix from changelog.

* test: Changed test_con_decimal_encode to @samuelcolvins recommendations

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
