### PR TITLE
chore(ci): update python 3.10 version (#3000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos, windows]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10.0-beta.2']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10.0-beta.4']
     env:
       PYTHON: ${{ matrix.python-version }}
       OS: ${{ matrix.os }}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -803,15 +803,10 @@ def test_literal_enum_values():
     with pytest.raises(ValidationError) as exc_info:
         Model(baz=FooEnum.bar)
 
-    if sys.version_info < (3, 10):
-        enum_repr = "<FooEnum.foo: 'foo_value'>"
-    else:
-        enum_repr = 'FooEnum.foo'
-
     assert exc_info.value.errors() == [
         {
             'loc': ('baz',),
-            'msg': f'unexpected value; permitted: {enum_repr}',
+            'msg': "unexpected value; permitted: <FooEnum.foo: 'foo_value'>",
             'type': 'value_error.const',
             'ctx': {'given': FooEnum.bar, 'permitted': (FooEnum.foo,)},
         },

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -835,10 +835,7 @@ def test_enum_successful():
     m = CookingModel(tool=2)
     assert m.fruit == FruitEnum.pear
     assert m.tool == ToolEnum.wrench
-    if sys.version_info < (3, 10):
-        assert repr(m.tool) == '<ToolEnum.wrench: 2>'
-    else:
-        assert repr(m.tool) == 'ToolEnum.wrench'
+    assert repr(m.tool) == '<ToolEnum.wrench: 2>'
 
 
 def test_enum_fails():
@@ -858,10 +855,7 @@ def test_enum_fails():
 def test_int_enum_successful_for_str_int():
     m = CookingModel(tool='2')
     assert m.tool == ToolEnum.wrench
-    if sys.version_info < (3, 10):
-        assert repr(m.tool) == '<ToolEnum.wrench: 2>'
-    else:
-        assert repr(m.tool) == 'ToolEnum.wrench'
+    assert repr(m.tool) == '<ToolEnum.wrench: 2>'
 
 
 def test_enum_type():


### PR DESCRIPTION
* chore(ci): update python 3.10 version

* Revert "fix: enum repr is different with 3.10+"

This reverts commit b1c8d9ef1396959ff9d88bb2ed16d99dd3146151.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
