### PR TITLE
chore(ci): remove warning filter for fastapi tests (#3001)

### DIFF
--- a/tests/test_fastapi.sh
+++ b/tests/test_fastapi.sh
@@ -12,7 +12,4 @@ git checkout "${latest_tag}"
 pip install -U flit
 flit install
 
-# ignore cryptography warning https://github.com/mpdavis/python-jose/issues/208
-PYTHONPATH=./docs/src pytest \
-  -W 'ignore:int_from_bytes is deprecated, use int.from_bytes instead:cryptography.utils.CryptographyDeprecationWarning' \
-  -W ignore::pytest.PytestCollectionWarning
+PYTHONPATH=./docs/src pytest


### PR DESCRIPTION
Now that https://github.com/tiangolo/fastapi/pull/2790 has been merged
in master, we don't need to filter those warnings anymore

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
